### PR TITLE
Changed GitHub Link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -141,8 +141,8 @@ html_copy_source = False
 
 html_context = {
     "display_github": True,
-    "github_user": "OTOBO",
-    "github_repo": "doc-user",
+    "github_user": "RotherOSS",
+    "github_repo": "doc-otobo-user",
     "github_version": "master",
     "conf_py_path": "/",
 }


### PR DESCRIPTION
The  'Edit on GitHub' in the top-right corner is not generated correctly.

Changed from:
https://github.com/OTOBO/doc-user/blob/master/content/index.rst
to
https://github.com/RotherOSS/doc-otobo-user/blob/master/content/index.rst